### PR TITLE
jlaura isn't there opencv3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - freetype=2.5.5=2
 - icu=54.1=0
 - jbig=2.1=0
-- jlaura::opencv3=3.0.0=py35_0
+- menpo::opencv3=3.1.0=py35_0
 - jpeg=9b=0
 - libpng=1.6.27=0
 - libtiff=4.0.6=3


### PR DESCRIPTION
Looks like the conda dep isn't there anymore for opencv3, just changed to menpo::opencv3=3.1.0=py35_0