### PR TITLE
Fixed no args performance

### DIFF
--- a/object_detection_app.py
+++ b/object_detection_app.py
@@ -89,9 +89,9 @@ if __name__ == '__main__':
     parser.add_argument('-src', '--source', dest='video_source', type=int,
                         default=0, help='Device index of the camera.')
     parser.add_argument('-wd', '--width', dest='width', type=int,
-                        default=480, help='Width of the frames in the video stream.')
+                        default=None, help='Width of the frames in the video stream.')
     parser.add_argument('-ht', '--height', dest='height', type=int,
-                        default=360, help='Height of the frames in the video stream.')
+                        default=None, help='Height of the frames in the video stream.')
     parser.add_argument('-num-w', '--num-workers', dest='num_workers', type=int,
                         default=2, help='Number of workers.')
     parser.add_argument('-q-size', '--queue-size', dest='queue_size', type=int,

--- a/utils/app_utils.py
+++ b/utils/app_utils.py
@@ -121,12 +121,14 @@ class HLSVideoStream:
 
 
 class WebcamVideoStream:
-	def __init__(self, src, width, height):
+	def __init__(self, src, width=None, height=None):
 		# initialize the video camera stream and read the first frame
 		# from the stream
 		self.stream = cv2.VideoCapture(src)
-		self.stream.set(cv2.CAP_PROP_FRAME_WIDTH, width)
-		self.stream.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+		if width:
+			self.stream.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+		if height:
+			self.stream.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
 		(self.grabbed, self.frame) = self.stream.read()
 
 		# initialize the variable used to indicate if the thread should


### PR DESCRIPTION
Fixed bug in multithreading version where default args.width & args.height values would be (probably incorrectly) used to scale bounding boxes. Now it uses the frame's actual size.
Edited WebcamVideoStream to support Nonetype/optional width & height constructor parameters